### PR TITLE
Added 'pte. ltd.' suffix for Singapore

### DIFF
--- a/cleanco/termdata.py
+++ b/cleanco/termdata.py
@@ -122,7 +122,7 @@ terms_by_country = {
    'Romania': ['s.c.a.', 's.c.s.', 's.n.c.', 's.r.l.', 'o.n.g.', 's.a.'],
    'Russia': ['ooo', 'oao', 'zao', '3ao', 'пао', 'оао', 'ооо'],
    'Serbia': ['d.o.o.', 'a.d.', 'k.d.', 'o.d.'],
-   'Singapore': ['bhd', 'pte ltd', 'sdn bhd', 'llp', 'l.l.p.', 'ltd.', 'pte'],
+   'Singapore': ['bhd', 'pte ltd', 'sdn bhd', 'llp', 'l.l.p.', 'ltd.', 'pte', 'pte. ltd.'],
    'Slovenia': ['d.d.', 'd.o.o.', 'd.n.o.', 'k.d.', 's.p.'],
    'Slovakia': ['a.s.', 'akc. spol.', 's.r.o.', 'spol. s r.o.', 'k.s.', 'kom. spol.', 'v.o.s.', 'a spol.'],
    'Spain': ['s.a.', 's.a.d.', 's.l.', 's.l.l.', 's.l.n.e.', 's.c.', 's.cra', 's.coop',


### PR DESCRIPTION
A common suffix used by companies in Singapore is Pte. Ltd., symbolizing a private limited company. This PR simply adds the suffix 'pte. ltd.' to the list of suffixes, making the list more complete.