### PR TITLE
Move prepare_terms() inside basename()

### DIFF
--- a/cleanco/clean.py
+++ b/cleanco/clean.py
@@ -73,10 +73,10 @@ def prepare_terms():
     return [(len(tp), tp) for tp in sntermparts]
 
 
-def basename(name, suffix=True, prefix=False, middle=False, **kwargs):
+def basename(name, terms=None, suffix=True, prefix=False, middle=False, **kwargs):
     "return cleaned base version of the business name"
-
-    terms = prepare_terms()
+    if terms is None:
+        terms = prepare_terms()
     name = strip_tail(name)
     nparts = name.split()
     nname = normalized(name)

--- a/cleanco/clean.py
+++ b/cleanco/clean.py
@@ -73,9 +73,10 @@ def prepare_terms():
     return [(len(tp), tp) for tp in sntermparts]
 
 
-def basename(name, terms, suffix=True, prefix=False, middle=False, **kwargs):
+def basename(name, suffix=True, prefix=False, middle=False, **kwargs):
     "return cleaned base version of the business name"
 
+    terms = prepare_terms()
     name = strip_tail(name)
     nparts = name.split()
     nname = normalized(name)


### PR DESCRIPTION
As discussed in issue #70

Made sure that the public API won't be broken from doing this by giving terms a default value of None