### PR TITLE
Fix issues with legal forms matching and add tests

### DIFF
--- a/cleanco/classify.py
+++ b/cleanco/classify.py
@@ -18,44 +18,52 @@ Examples of use:
 """
 
 from .termdata import terms_by_country, terms_by_type
-from .clean import strip_tail, normalized
+from .utils import strip_punct, strip_tail, normalized, normalize_terms, find_sublist
 
 
 def typesources():
-   "business types / abbreviations sorted by length of business type"
-   types = []
-   for business_type in terms_by_type:
-       for item in terms_by_type[business_type]:
-           types.append((business_type, item))
+    "business types / abbreviations sorted by length of business type"
+    types = []
+    for business_type, type_terms in terms_by_type.items():
+        for item in set(normalize_terms(type_terms)):
+            types.append((business_type, item.split()))
 
-   return sorted(types, key=lambda part: len(part[1]), reverse=True)
+    return sorted(types, key=lambda part: len(part[1]), reverse=True)
 
 
 def countrysources():
-   "business countries / type abbreviations sorted by length of type abbreviations"
-   countries = []
-   for country in terms_by_country:
-       for item in terms_by_country[country]:
-           countries.append((country, item))
+    "business countries / type abbreviations sorted by length of type abbreviations"
+    countries = []
+    for country, country_terms in terms_by_country.items():
+        for item in set(normalize_terms(country_terms)):
+            countries.append((country, item.split()))
 
-   return sorted(countries, key=lambda part: len(part[1]), reverse=True)
+    return sorted(countries, key=lambda part: len(part[1]), reverse=True)
 
 
 def matches(name, sources):
     "get types or countries matching with the legal terms in name"
-
     name = strip_tail(name)
-    parts = name.split()
-    nparts = [normalized(p) for p in parts]
+    nname = normalized(name)
+    nnparts = list(map(strip_punct, nname.split()))
+
     matches = []
     for classifier, term in sources:
-        nterm = normalized(term)
-        try:
-            idx = nparts.index(nterm)
-        except ValueError:
-            pass
-        else:
-            matches.append(classifier)
+        if find_sublist(nnparts, term):
+            matches.append((classifier, term))
 
-    return matches
+    # sort by length of matched tokens
+    matches = sorted(matches, key=lambda x: -len(x[1]))
+    disamb_matches = []
 
+    # removing matches that are part of a longer better match
+    for classifier, term in matches:
+        # if there is a term in disamb_matches that already
+        # contains the new term skip it, otherwise add
+        if not any(
+            len(term_other) > len(term) and find_sublist(term_other, term)
+            for _, term_other in disamb_matches
+        ):
+            disamb_matches.append((classifier, term))
+
+    return [class_ for class_, _ in disamb_matches]

--- a/cleanco/clean.py
+++ b/cleanco/clean.py
@@ -13,13 +13,8 @@ Daddy & Sons
 
 import functools
 import operator
-from collections import OrderedDict
-import re
-import unicodedata
 from .termdata import terms_by_type, terms_by_country
-from .non_nfkd_map import NON_NFKD_MAP
-
-tail_removal_rexp = re.compile(r"[^\.\w]+$", flags=re.UNICODE)
+from .utils import strip_punct, normalize_terms, strip_tail, normalized
 
 
 def get_unique_terms():
@@ -27,40 +22,6 @@ def get_unique_terms():
     ts = functools.reduce(operator.iconcat, terms_by_type.values(), [])
     cs = functools.reduce(operator.iconcat, terms_by_country.values(), [])
     return set(ts + cs)
-
-
-def remove_accents(t):
-    """based on https://stackoverflow.com/a/51230541"""
-    nfkd_form = unicodedata.normalize('NFKD', t.casefold())
-    return ''.join(
-        NON_NFKD_MAP[c]
-            if c in NON_NFKD_MAP
-        else c
-            for part in nfkd_form for c in part
-            if unicodedata.category(part) != 'Mn'
-        )
-
-
-def strip_punct(t):
-    return t.replace(".", "").replace(",", "").replace("-", "")
-
-
-def normalize_terms(terms):
-    "normalize terms"
-    return (strip_punct(remove_accents(t)) for t in terms)
-
-
-def strip_tail(name):
-    "get rid of all trailing non-letter symbols except the dot"
-    match = re.search(tail_removal_rexp, name)
-    if match is not None:
-        name = name[: match.span()[0]]
-    return name
-
-
-def normalized(text):
-    "caseless Unicode normalization"
-    return remove_accents(text)
 
 
 def prepare_terms():
@@ -99,17 +60,14 @@ def basename(name, terms, suffix=True, prefix=False, middle=False, **kwargs):
             if termsize > 1:
                 sizediff = nnsize - termsize
                 if sizediff > 1:
-                    for i in range(0, nnsize-termsize+1):
-                        if termparts == nnparts[i:i+termsize]:
-                            del nnparts[i:i+termsize]
-                            del nparts[i:i+termsize]
+                    for i in range(0, nnsize - termsize + 1):
+                        if termparts == nnparts[i : i + termsize]:
+                            del nnparts[i : i + termsize]
+                            del nparts[i : i + termsize]
             else:
                 if termparts[0] in nnparts[1:-1]:
                     idx = nnparts[1:-1].index(termparts[0])
-                    del nnparts[idx+1]
-                    del nparts[idx+1]
-
+                    del nnparts[idx + 1]
+                    del nparts[idx + 1]
 
     return strip_tail(" ".join(nparts))
-
-

--- a/cleanco/utils.py
+++ b/cleanco/utils.py
@@ -1,0 +1,53 @@
+import unicodedata
+from .non_nfkd_map import NON_NFKD_MAP
+import re
+
+tail_removal_rexp = re.compile(r"[^\.\w]+$", flags=re.UNICODE)
+
+
+def remove_accents(t):
+    """based on https://stackoverflow.com/a/51230541"""
+    nfkd_form = unicodedata.normalize("NFKD", t.casefold())
+    return "".join(
+        NON_NFKD_MAP[c] if c in NON_NFKD_MAP else c
+        for part in nfkd_form
+        for c in part
+        if unicodedata.category(part) != "Mn"
+    )
+
+
+def strip_punct(t):
+    return t.replace(".", "").replace(",", "").replace("-", "")
+
+
+def normalize_terms(terms):
+    "normalize terms"
+    return (strip_punct(remove_accents(t)) for t in terms)
+
+
+def strip_tail(name):
+    "get rid of all trailing non-letter symbols except the dot"
+    match = re.search(tail_removal_rexp, name)
+    if match is not None:
+        name = name[: match.span()[0]]
+    return name
+
+
+def normalized(text):
+    "caseless Unicode normalization"
+    return remove_accents(text)
+
+def find_sublist(mylist, pattern):
+    """
+    Inspired by https://stackoverflow.com/questions/10106901/elegant-find-sub-list-in-list
+    """
+    assert len(pattern) > 0 and len(mylist) > 0
+    if len(pattern) > len(mylist):
+        return False
+
+    matches = []
+    for i in range(len(mylist)-len(pattern)+1):
+        if mylist[i] == pattern[0] and mylist[i:i+len(pattern)] == pattern:
+            #matches.append(pattern)
+            return True
+    return False

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -1,0 +1,166 @@
+# encoding: utf-8
+import pytest
+from cleanco import matches
+from cleanco import typesources, countrysources
+
+print(countrysources())
+
+
+@pytest.fixture
+def country_sources():
+    return countrysources()
+
+
+@pytest.fixture
+def type_sources():
+    return typesources()
+
+
+# Tests that demonstrate stuff is classified
+
+basic_class_tests = {
+    "name w/ suffix": "Hello World Gmbh",
+    "name w/ ', suffix.'": "Hello World, gmbh.",
+    "name w/ ws suffix ws": "Hello    World gmbh",
+    "name w/ suffix ws": "Hello World gmbh ",
+    "name w/ suffix dot ws": "Hello World gmbh. ",
+    "name w/ ws suffix dot ws": " Hello World gmbh. ",
+}
+
+
+def test_basic_country_class(country_sources):
+    expected = ["Germany", "Switzerland"]
+    errmsg = "cleanup of %s failed"
+    for testname, variation in basic_class_tests.items():
+        assert matches(variation, country_sources) == expected, errmsg % testname
+
+
+def test_basic_type_class(type_sources):
+    expected = ["Limited"]
+    errmsg = "cleanup of %s failed"
+    for testname, variation in basic_class_tests.items():
+        assert matches(variation, type_sources) == expected, errmsg % testname
+
+
+# Tests that demonstrate legal forms with multiple terms are classified
+
+multiterm_class_tests = {
+    "name w/ suffix": "Hello World akc. spol.",
+    "name w/ ', suffix.'": "Hello World, akc. spol.",
+    "name w/ ws suffix ws": "Hello    World akc. spol. ",
+    "name w/ suffix ws": "Hello World akc spol ",
+    "name w/ ws suffix dot ws": " Hello World akc. spol. ",
+}
+
+
+def test_basic_country_classifications(country_sources):
+    expected = ["Czech Republic", "Slovakia"]
+    errmsg = "cleanup of %s failed"
+    for testname, variation in multiterm_class_tests.items():
+        assert matches(variation, country_sources) == expected, errmsg % testname
+
+
+def test_basic_type_classifications(type_sources):
+    expected = ["Joint Stock / Unlimited"]
+    errmsg = "cleanup of %s failed"
+    for testname, variation in multiterm_class_tests.items():
+        assert matches(variation, type_sources) == expected, errmsg % testname
+
+
+def test_accents_in_names(type_sources):
+    assert matches("Polsko spółka z o.o.", type_sources) == ["Limited"]
+    assert matches("Polsko społka z o.o.", type_sources) == ["Limited"]
+
+
+def test_possible_ambiguities(type_sources):
+    testname = "Germany gmbh & co. kg"
+    errmsg = "cleanup of %s failed"
+    assert matches(testname, type_sources) == ["Limited Partnership"], errmsg % testname
+
+
+"""
+multi_cleanup_tests = {
+    "name + suffix": "Hello World Oy",
+    "name + suffix (without punct)": "Hello World sro",
+    "prefix + name": "Oy Hello World",
+    "prefix + name + suffix": "Oy Hello World Ab",
+    "name w/ term in middle": "Hello Oy World",
+    "name w/ complex term in middle": "Hello pty ltd World",
+    "name w/ mid + suffix": "Hello Oy World Ab",
+}
+
+
+def test_multi_type_cleanups(terms):
+    expected = "Hello World"
+    errmsg = "cleanup of %s failed"
+    for testname, variation in multi_cleanup_tests.items():
+        result = basename(variation, terms, prefix=True, suffix=True, middle=True)
+        assert result == expected, errmsg % testname
+
+
+# Tests that demonstrate basename can be run twice effectively
+
+double_cleanup_tests = {
+    "name + two prefix": "Ab Oy Hello World",
+    "name + two suffix": "Hello World Ab Oy",
+    "name + two in middle": "Hello Ab Oy World",
+}
+
+
+def test_double_cleanups(terms):
+    expected = "Hello World"
+    errmsg = "cleanup of %s failed"
+    for testname, variation in multi_cleanup_tests.items():
+        result = basename(variation, terms, prefix=True, suffix=True, middle=True)
+        final = basename(result, terms, prefix=True, suffix=True, middle=True)
+
+        assert final == expected, errmsg % testname
+
+
+# Tests that demonstrate organization name is kept intact
+
+preserving_cleanup_tests = {
+    "name with comma": ("Hello, World, ltd.", "Hello, World"),
+    "name with dot": ("Hello. World, Oy", "Hello. World"),
+}
+
+
+def test_preserving_cleanups(terms):
+    errmsg = "preserving cleanup of %s failed"
+    for testname, (variation, expected) in preserving_cleanup_tests.items():
+        assert basename(variation, terms) == expected, errmsg % testname
+
+
+# Test umlauts
+
+
+unicode_umlaut_tests = {
+    "name with umlaut in end": ("Säätämö Oy", "Säätämö"),
+    "name with umlauts & comma": ("Säätämö, Oy", "Säätämö"),
+    "name with no ending umlaut": ("Säätämo Oy", "Säätämo"),
+    "name with beginning umlaut": ("Äätämo Oy", "Äätämo"),
+    "name with just umlauts": ("Äätämö", "Äätämö"),
+    "cyrillic name": (
+        "ОАО Новороссийский морской торговый порт",
+        "Новороссийский морской торговый порт",
+    ),
+}
+
+
+def test_with_unicode_umlauted_name(terms):
+    errmsg = "preserving cleanup of %s failed"
+    for testname, (variation, expected) in unicode_umlaut_tests.items():
+        assert basename(variation, terms, prefix=True) == expected, errmsg % testname
+
+
+terms_with_accents_tests = {
+    "term with ł correct spelling": ("Łoś spółka z o.o", "Łoś"),
+    "term with ł incorrect spelling": ("Łoś spolka z o.o", "Łoś"),
+}
+
+
+def test_terms_with_accents(terms):
+    errmsg = "preserving cleanup of %s failed"
+    for testname, (variation, expected) in terms_with_accents_tests.items():
+        assert basename(variation, terms, suffix=True) == expected, errmsg % testname
+ """


### PR DESCRIPTION
There were several issues that are being addressed here:
1) The matching worked only for companies with one token legal forms (such as plc, ltd) etc
2) The matching was returning ambiguous results that could be disambiguated. When the input name had `gmbh & co. kg` as a legal form, the matching returned countries and types only for `gmbh` which is a different legal form. So now there is a mechanism that handles this.
3) There were tests for `basename` cleaning but nothing for matching the legal forms, so I added at least basic tests.
