### PR TITLE
Allow closing parenthesis as valid trailing symbol

### DIFF
--- a/cleanco/clean.py
+++ b/cleanco/clean.py
@@ -19,7 +19,7 @@ import unicodedata
 from .termdata import terms_by_type, terms_by_country
 from .non_nfkd_map import NON_NFKD_MAP
 
-tail_removal_rexp = re.compile(r"[^\.\w]+$", flags=re.UNICODE)
+tail_removal_rexp = re.compile(r"[^\.\w)]+$", flags=re.UNICODE)
 
 
 def get_unique_terms():

--- a/tests/test_cleanname.py
+++ b/tests/test_cleanname.py
@@ -71,7 +71,8 @@ def test_double_cleanups():
 
 preserving_cleanup_tests = {
    "name with comma": ("Hello, World, ltd.", "Hello, World"),
-   "name with dot": ("Hello. World, Oy", "Hello. World")
+   "name with dot": ("Hello. World, Oy", "Hello. World"),
+   "name ending with closing parenthesis": ("Hello World (Country) Ltd.", "Hello World (Country)"),
 }
 
 def test_preserving_cleanups():


### PR DESCRIPTION
Fixes #61 
Since we are looking at the tail, I decided to only allow `)`. I don't see how a valid name could end in `(`